### PR TITLE
Adding common arch sources

### DIFF
--- a/bkp
+++ b/bkp
@@ -110,6 +110,21 @@ SOURCES = {
         "install": ["gem", "install"],
         "list": ["gem", "list", "--no-verbose", "--no-versions"],
         "singleCmd": True
+    },
+    "pacman": {
+        "install": ["pacman", "-Sy", "--noconfirm"],
+        "list": ["pacman", "-Qq"],
+        "singleCmd": True
+    },
+    "yay": {
+            "install": ["yay", "-Sy", "--noconfirm"],
+            "list": ["yay", "-Qq"],
+            "singleCmd": True
+    },
+    "paru": {
+            "install": ["paru", "-Sy", "--noconfirm"],
+            "list": ["paru", "-Qq"],
+            "singleCmd": True
     }
 }
 # end::sources[]


### PR DESCRIPTION
Using the --noconfirm flag might not provide the desired outcome if the defaults do not align with the user's expectations. Moreover, neglecting to review upgrade/deletion prompts from the package manager/s might lead to the unexpected behaviure such as a full system breakage in the worst possible case, but yolo i guess.